### PR TITLE
block: Disable add_random

### DIFF
--- a/include/linux/blkdev.h
+++ b/include/linux/blkdev.h
@@ -475,7 +475,7 @@ struct request_queue {
 #define QUEUE_FLAG_DEFAULT	((1 << QUEUE_FLAG_IO_STAT) |		\
 				 (1 << QUEUE_FLAG_STACKABLE)	|	\
 				 (1 << QUEUE_FLAG_SAME_COMP)	|	\
-				 (1 << QUEUE_FLAG_ADD_RANDOM))
+				 (0 << QUEUE_FLAG_ADD_RANDOM))
 
 static inline void queue_lockdep_assert_held(struct request_queue *q)
 {


### PR DESCRIPTION
add_random was implemented for spinning hard disks.  It only slows SSDs down.  Read here http://wiki.samat.org/SSD for more info.

Signed-off-by: Chester Kener <Cl3Kener@gmail.com>
Signed-off-by: engstk <eng.stk@sapo.pt>